### PR TITLE
Allow `esmlm` to pass arguments to the underlying program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
+## [0.2.0]
+### Added
+* [#2]: The `esmlm` binary passes arguments to the underlying program.
+
 ## 0.1.0 – 2022-05-26
 ### Added
 * First working version, yay!
 
+[#2]: https://github.com/Comandeer/esm-loader-manager/issues/2
+
+[0.2.0]: https://github.com/Comandeer/esm-loader-manager/compare/v0.1.0...v0.2.0

--- a/bin/esmlm.js
+++ b/bin/esmlm.js
@@ -13,13 +13,14 @@ const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const loaderPath = resolvePath( __dirname, '..', 'dist', 'esm-loader-manager.mjs' );
 const loaderURL = pathToFileURL( loaderPath );
 const cwd = processCWD();
-const [ ,, passedEntryPoint ] = argv;
+const [ ,, passedEntryPoint, ...args ] = argv;
 const entryPoint = passedEntryPoint ? resolvePath( cwd, passedEntryPoint ) : cwd;
 const cmd = 'node';
 const params = [
 	'--experimental-loader',
 	loaderURL,
-	entryPoint
+	entryPoint,
+	...args
 ];
 
 const { exitCode } = await execa( cmd, params, {

--- a/tests/__fixtures__/esmlmArgs/.esmlmrc.js
+++ b/tests/__fixtures__/esmlmArgs/.esmlmrc.js
@@ -1,0 +1,3 @@
+export default {
+	loaders: []
+};

--- a/tests/__fixtures__/esmlmArgs/index.js
+++ b/tests/__fixtures__/esmlmArgs/index.js
@@ -1,0 +1,5 @@
+import { argv } from 'node:process';
+
+const filteredArgs = argv.splice( 2 );
+
+console.log( filteredArgs.join( ' ' ) );

--- a/tests/__fixtures__/esmlmArgs/package.json
+++ b/tests/__fixtures__/esmlmArgs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "esmlm-args",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "license": "UNLICENSED"
+}

--- a/tests/__helpers__/createEsmlmTest.js
+++ b/tests/__helpers__/createEsmlmTest.js
@@ -16,6 +16,7 @@ const __dirname = dirname( fileURLToPath( import.meta.url ) );
  * @typedef {Object} EsmlmTestOptions
  * @property {string} cwd Path to the cwd.
  * @property {string} [entryPoint] The file name to be exectued by Node.
+ * @property {Array<string>} [args] Arguments to be passed to the program.
  * @property {Record<string, string>} [env={}] Additional environment variables to pass to the command.
  * @property {EsmlmTestCallback} callback Callback to invoke after executing command.
  */
@@ -27,14 +28,18 @@ const __dirname = dirname( fileURLToPath( import.meta.url ) );
 function createEsmlmTest( {
 	cwd,
 	entryPoint,
+	args = [],
 	env = {},
 	callback: userCallback
 } = {} ) {
 	const esmlmPath = resolvePath( __dirname, '..', '..', 'bin', 'esmlm.js' );
 	const cmd = esmlmPath;
 	const params = entryPoint ? [
-		entryPoint
-	] : [];
+		entryPoint,
+		...args
+	] : [
+		...args
+	];
 
 	// Do not propagate coverage into esmlm binary.
 	// For some reason it breaks the coverage calculation.

--- a/tests/esmlm.js
+++ b/tests/esmlm.js
@@ -7,8 +7,14 @@ import createEsmlmTest from './__helpers__/createEsmlmTest.js';
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const fixtureDirPath = resolvePath( __dirname, '__fixtures__' );
 const esmlmFixturePath = resolvePath( fixtureDirPath, 'esmlm' );
-const entryPointPath = resolvePath( esmlmFixturePath, 'index.js' );
+const esmlmFixtureEntryPointPath = resolvePath( esmlmFixturePath, 'index.js' );
+const esmlmArgsFixturePath = resolvePath( fixtureDirPath, 'esmlmArgs' );
+const esmlmArgsFixtureEntryPointPath = resolvePath( esmlmArgsFixturePath, 'index.js' );
 const successfulExitCode = 0;
+const sampleArgs = [
+	'some-path',
+	'--some-arg'
+];
 
 test( 'esmlm correctly launches Node.js module without any parameters', createEsmlmTest( {
 	cwd: esmlmFixturePath,
@@ -20,7 +26,7 @@ test( 'esmlm correctly launches Node.js module without any parameters', createEs
 
 test( 'esmlm correctly launches Node.js module with the absolute path as the parameter', createEsmlmTest( {
 	cwd: esmlmFixturePath,
-	entryPoint: entryPointPath,
+	entryPoint: esmlmFixtureEntryPointPath,
 	callback( t, { stdout, exitCode } ) {
 		t.is( stdout, 'true' );
 		t.is( exitCode, successfulExitCode );
@@ -53,5 +59,16 @@ test( 'esmlm throws error when incorrect relative path is passed as the paramete
 
 		t.regex( stderr, moduleNotFoundError );
 		t.not( exitCode, 0 );
+	}
+} ) );
+
+// #2
+test.only( 'esmlm correctly passes arguments to the underlying program', createEsmlmTest( {
+	cwd: esmlmArgsFixturePath,
+	entryPoint: esmlmArgsFixtureEntryPointPath,
+	args: sampleArgs,
+	callback( t, { stdout, exitCode } ) {
+		t.is( stdout, sampleArgs.join( ' ' ) );
+		t.is( exitCode, successfulExitCode );
 	}
 } ) );

--- a/tests/esmlm.js
+++ b/tests/esmlm.js
@@ -63,7 +63,7 @@ test( 'esmlm throws error when incorrect relative path is passed as the paramete
 } ) );
 
 // #2
-test.only( 'esmlm correctly passes arguments to the underlying program', createEsmlmTest( {
+test( 'esmlm correctly passes arguments to the underlying program', createEsmlmTest( {
 	cwd: esmlmArgsFixturePath,
 	entryPoint: esmlmArgsFixtureEntryPointPath,
 	args: sampleArgs,


### PR DESCRIPTION
Closes #2.