### PR TITLE
fix(utilities): fix incorrect results returned by `isInsideDir()` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
+## [0.3.0]
+### Fixed
+* [#6]: Incorrect results returned by `isInsideDir()` on Windows.
+
 ## [0.2.0] – 2022-07-27
 ### Added
 * [#2]: The `esmlm` binary passes arguments to the underlying program.
@@ -23,5 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#1]: https://github.com/Comandeer/esm-loader-manager/issues/1
 [#2]: https://github.com/Comandeer/esm-loader-manager/issues/2
 [#5]: https://github.com/Comandeer/esm-loader-manager/issues/5
+[#6]: https://github.com/Comandeer/esm-loader-manager/issues/6
 
+[0.3.0]: https://github.com/Comandeer/esm-loader-manager/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Comandeer/esm-loader-manager/compare/v0.1.0...v0.2.0

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,5 +1,6 @@
 import { readdir } from 'node:fs/promises';
 import { readFile } from 'node:fs/promises';
+import { isAbsolute } from 'node:path';
 import { relative as getRelativePath } from 'node:path';
 import { resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -57,12 +58,15 @@ async function resolveConfigFile( startDir, projectRoot ) {
 	return resolveConfigFile( dirUp );
 }
 
-function isInsideDir( dir, path ) {
-	const filePath = path.startsWith( 'file://' ) ? fileURLToPath( path ) : path;
+function isInsideDir( dir, pathOrURL ) {
+	const filePath = pathOrURL.startsWith( 'file://' ) ? fileURLToPath( pathOrURL ) : pathOrURL;
 	const relativePath = getRelativePath( dir, filePath );
+	const isNotEmptyPath = relativePath.length > 0;
+	const isNotOutsideDir = !relativePath.startsWith( '..' );
+	const isNotAbsolutePath = !isAbsolute( relativePath );
 
-	// https://www.golinuxcloud.com/if-path-is-subdirectory-of-another-nodejs/
-	return !relativePath.startsWith( '..' );
+	// https://stackoverflow.com/a/45242825/9025529
+	return isNotEmptyPath && isNotOutsideDir && isNotAbsolutePath;
 }
 
 function isInsideNodeModules( pathOrURL ) {


### PR DESCRIPTION
Closes #6.